### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Deploy p2 update site
         if: github.ref == 'refs/heads/main' && runner.os == 'Linux'
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1 #latest
         with:
           repo_token: "${{secrets.GITHUB_TOKEN}}"
           automatic_release_tag: "latest"
@@ -53,7 +53,7 @@ jobs:
             org.jboss.tools.m2e.wro4j.site/target/flat-repository/*
       
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 #v1
         if: startsWith(github.ref, 'refs/tags/') && runner.os == 'Linux'
         with:
           files: |


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
